### PR TITLE
Fix StatefulSet scale down

### DIFF
--- a/deploy/charts/proxysql-cluster/templates/statefulset.yaml
+++ b/deploy/charts/proxysql-cluster/templates/statefulset.yaml
@@ -53,6 +53,13 @@ spec:
             - mountPath: /etc/proxysql.cnf
               name: proxysql
               subPath: proxysql.cnf
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - "/usr/bin/proxysql-cli remove"
           {{ if .Values.resources }}
           resources:
 {{ .Values.resources | indent 12 }}

--- a/docker/files/cli/commands/cluster.sh
+++ b/docker/files/cli/commands/cluster.sh
@@ -53,9 +53,18 @@ command_query:rules() {
     proxysql_execute_query_hr "SELECT * FROM mysql_query_rules"
 }
 
-commands_add "query:nodes" "Show al the nodes of the cluster"
+commands_add "query:nodes" "Show all the nodes of the cluster"
 command_query:nodes() {
     proxysql_execute_query_hr "SELECT * FROM proxysql_servers;"
+}
+
+commands_add "remove" "Remove this node from the cluster"
+command_remove() {
+    proxysql_execute_query_hr "
+        DELETE FROM proxysql_servers
+        WHERE hostname = '${IP}';
+        LOAD PROXYSQL SERVERS TO RUN;
+    " ${PROXYSQL_SERVICE}
 }
 
 commands_add "sync" "Synchronize from backends"


### PR DESCRIPTION
# Description

Two things in this pull request:

- New cluster function `command_remove` that connects to the proxysql cluster service and removes the current node
- `preStop` lifecycle hook to invoke `proxysql-cli remove` prior to pod termination

Fixes #37.