### PR TITLE
show errors and replace users when syncing on existing data

### DIFF
--- a/docker/files/cli/commands/cluster.sh
+++ b/docker/files/cli/commands/cluster.sh
@@ -132,8 +132,8 @@ command_sync() {
                 " ${hostname} | while read username password database; do
 
                     proxysql_execute_query "
-                        INSERT INTO mysql_users (username, password, default_schema, default_hostgroup)
-                        VALUES ('${username}', '${password}', '${database}', '${hostgroup}');" &> /dev/null
+                        REPLACE INTO mysql_users (username, password, default_schema, default_hostgroup)
+                        VALUES ('${username}', '${password}', '${database}', '${hostgroup}');"
 
                     if [[ ${?} -eq 1 ]]; then
                         echo -e "Adding ${username}:${database} failed"


### PR DESCRIPTION
In k8s the proxySql sync feature is uses for a new node, so there is never a problem with existing user, but when I use the image stand-alone in docker I'd like to `REPLACE INTO` and sync over existing data.